### PR TITLE
fix(ui): checks truthy value for last ingested

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/EntitySidebar.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/EntitySidebar.tsx
@@ -46,7 +46,7 @@ export const EntitySidebar = <T,>({ sidebarSections, topSection }: Props) => {
     return (
         <>
             {topSection && <topSection.component key={`${topSection.component}`} properties={topSection.properties} />}
-            {entityData?.lastIngested && (
+            {!!(entityData?.lastIngested) && (
                 <LastIngestedSection>
                     <LastIngested lastIngested={entityData.lastIngested} />
                 </LastIngestedSection>


### PR DESCRIPTION
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md


When lastIngested is 0, 0 gets rendered on the screen.
